### PR TITLE
Update the link to the Py-Pkg whole-game chapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cookiecutter UBC-MDS
 
-**Cookiecutter** template for creating a Python packge using [Poetry](https://python-poetry.org/). See the [Quickstart](#quickstart) guide below for getting started, or for a more guided introduction see [the Whole Game chapter of the Python packages book](https://ubc-mds.github.io/py-pkgs/whole-game.html).
+**Cookiecutter** template for creating a Python packge using [Poetry](https://python-poetry.org/). See the [Quickstart](#quickstart) guide below for getting started, or for a more guided introduction see [the Whole Game chapter of the Python packages book](https://py-pkgs.org/chapters/02-the-whole-game).
 
 -  Free software: BSD license
 


### PR DESCRIPTION
#### Description:
- The previous link went to '404 File not found'
  old link: https://ubc-mds.github.io/py-pkgs/whole-game.html
- New Link: https://py-pkgs.org/chapters/02-the-whole-game

#### Test:
- Generated the GitHub markup of the new README.md version and clicked the link to ' the Whole Game chapter of the Python packages book.'. The result is that it successfully when to the 'https://py-pkgs.org/chapters/02-the-whole-game'.
----
Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC