### PR TITLE
Fix to GHA for main branch and relying on python 3.7

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,9 +17,5 @@
     "no",
     "build",
     "build+deploy"
-  ],
-  "_copy_without_render": [
-    ".github/workflows/build.yml",
-    ".github/workflows/deploy.yml"
   ]
 }

--- a/{{cookiecutter.project_slug}}/.github/workflows/build.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/build.yml
@@ -1,21 +1,21 @@
-name: build
+{% raw %}name: build
 
 on:
-  # Trigger the workflow on push or pull request to master
+  # Trigger the workflow on push or pull request to main
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7]
+        os: [ubuntu-latest, macos-latest, windows-latest]{% endraw %}
+        python-version: [{{cookiecutter.python_version}}]{% raw %}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -38,3 +38,4 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true
+{% endraw %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/deploy.yml
@@ -1,20 +1,20 @@
 name: Deploy
 
 on:
-  # Trigger the workflow on push or pull request to master
+  # Trigger the workflow on push or pull request to main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python {{cookiecutter.python_version}}
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: {{cookiecutter.python_version}}{% raw %}
     - name: Install dependencies
       run: |
         pip install poetry
@@ -69,3 +69,4 @@ jobs:
         poetry config repositories.test-pypi https://test.pypi.org/legacy/
         poetry build
         poetry publish -r test-pypi -u $TEST_PYPI_USERNAME -p $TEST_PYPI_PASSWORD
+{% endraw %}


### PR DESCRIPTION
1. GHA still used master as trigger branch
2. GHA had python 3.7 hardcoded