### PR TITLE
(fix): removing version from tests

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -1,5 +1,2 @@
 from {{ cookiecutter.project_slug }} import __version__
 from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}
-
-def test_version():
-    assert __version__ == {{cookiecutter.version}}


### PR DESCRIPTION
Having the package version in the tests file breaks semver tooling. Thus I propose we remove this until we can figure out how to have semver bump this (not sure it's possible with the current tool we use or any that exist...)