### PR TITLE
✨ NEW: include pyproject.toml generation in cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "github_username": "mpython",
   "project_name": "My Python package",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
-  "project_short_description": "A package for doing great things.",
+  "project_short_description": "A package for doing great things!",
   "version": "0.1.0",
   "python_version": "3.9",
   "open_source_license": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "full_name": "Monty Python",
+  "author_name": "Monty Python",
   "github_username": "mpython",
   "project_name": "My Python package",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,8 +3,8 @@
   "github_username": "mpython",
   "project_name": "My Python package",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
-  "project_short_description": "This cookiecutter creates a boilerplate for a Python project.",
-  "version": "'0.1.0'",
+  "project_short_description": "A package for doing great things.",
+  "version": "0.1.0",
   "python_version": "3.9",
   "open_source_license": [
     "MIT",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,13 +5,12 @@
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_short_description": "This cookiecutter creates a boilerplate for a Python project.",
   "version": "'0.1.0'",
-  "python_version": "3.8",
+  "python_version": "3.9",
   "open_source_license": [
-    "MIT license",
-    "BSD license",
-    "ISC license",
-    "Apache Software License 2.0",
-    "GNU General Public License v3",
+    "MIT",
+    "Apache License 2.0",
+    "GNU General Public License v3.0",
+    "Creative Commons Attribution 4.0",
     "None"
   ],
   "include_github_actions": [

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -49,21 +49,21 @@ def test_cookiecutter_all_options(
     if open_source_license == "None":
         if include_github_actions == "build":
             assert num_items(path, [".github", "workflows"]) == 1
-            assert num_items(path) == 9
+            assert num_items(path) == 10
         elif include_github_actions == "build+deploy":
             assert num_items(path, [".github", "workflows"]) == 2
-            assert num_items(path) == 9
+            assert num_items(path) == 10
         else:
-            assert num_items(path) == 8
+            assert num_items(path) == 9
     else:
         if include_github_actions == "build":
             assert num_items(path, [".github", "workflows"]) == 1
-            assert num_items(path) == 10
+            assert num_items(path) == 11
         elif include_github_actions == "build+deploy":
             assert num_items(path, [".github", "workflows"]) == 2
-            assert num_items(path) == 10
+            assert num_items(path) == 11
         else:
-            assert num_items(path) == 9
+            assert num_items(path) == 10
 
 
 @mark.parametrize(

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,7 +1,7 @@
 {% if cookiecutter.open_source_license == 'MIT license' -%}
 MIT License
 
-Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@ SOFTWARE.
 
 BSD License
 
-Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -54,7 +54,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 {% elif cookiecutter.open_source_license == 'ISC license' -%}
 ISC License
 
-Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
@@ -62,7 +62,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 {% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
 Apache Software License 2.0
 
-Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
     {{ cookiecutter.project_short_description }}
-    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.full_name }}
+    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author_name }}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -20,14 +20,15 @@
 # import {{cookiecutter.project_slug}}
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
 
-project = u'{{ cookiecutter.project_name }}'
-copyright = u"{% now 'local', '%Y' %}, {{ cookiecutter.full_name }}"
-author = u"{{ cookiecutter.full_name }}"
+project = u"{{ cookiecutter.project_name }}"
+copyright = u"{% now 'local', '%Y' %}, {{ cookiecutter.author_name }}"
+author = u"{{ cookiecutter.author_name }}"
 
 # -- General configuration ---------------------------------------------
 
@@ -37,21 +38,23 @@ author = u"{{ cookiecutter.full_name }}"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.napoleon']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -72,10 +75,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -85,21 +88,19 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_sidebars = {
-    "**": ["about.html", "navigation.html", "searchbox.html"]
-}
+html_sidebars = {"**": ["about.html", "navigation.html", "searchbox.html"]}
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '{{ cookiecutter.project_slug }}doc'
+htmlhelp_basename = "{{ cookiecutter.project_slug }}doc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -108,15 +109,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -126,9 +124,13 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, '{{ cookiecutter.project_slug }}.tex',
-     u'{{ cookiecutter.project_name }} Documentation',
-     u'{{ cookiecutter.full_name }}', 'manual'),
+    (
+        master_doc,
+        "{{ cookiecutter.project_slug }}.tex",
+        u"{{ cookiecutter.project_name }} Documentation",
+        u"{{ cookiecutter.author_name }}",
+        "manual",
+    ),
 ]
 
 
@@ -137,9 +139,13 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, '{{ cookiecutter.project_slug }}',
-     u'{{ cookiecutter.project_name }} Documentation',
-     [author], 1)
+    (
+        master_doc,
+        "{{ cookiecutter.project_slug }}",
+        u"{{ cookiecutter.project_name }} Documentation",
+        [author],
+        1,
+    )
 ]
 
 
@@ -149,10 +155,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, '{{ cookiecutter.project_slug }}',
-     u'{{ cookiecutter.project_name }} Documentation',
-     author,
-     '{{ cookiecutter.project_slug }}',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "{{ cookiecutter.project_slug }}",
+        u"{{ cookiecutter.project_name }} Documentation",
+        author,
+        "{{ cookiecutter.project_slug }}",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "{{ cookiecutter.project_slug }}"
+version = "{{ cookiecutter.version }}"
+description = "{{ cookiecutter.project_short_description }}"
+authors = ["{{ cookiecutter.full_name }}"]
+license = "{{ cookiecutter.open_source_license }}"
+readme = "README.md"
+documentation = "https://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/"
+homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+
+[tool.poetry.dependencies]
+python = "^{{ cookiecutter.python_version }}"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -2,7 +2,7 @@
 name = "{{ cookiecutter.project_slug }}"
 version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.project_short_description }}"
-authors = ["{{ cookiecutter.full_name }}"]
+authors = ["{{ cookiecutter.author_name }}"]
 license = "{{ cookiecutter.open_source_license }}"
 readme = "README.md"
 documentation = "https://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
@@ -1,1 +1,1 @@
-__version__ = {{cookiecutter.version}}
+__version__ = "{{ cookiecutter.version }}"


### PR DESCRIPTION
Closes #3 

Adds pyproject.toml generation to cookiecutter to avoid redundancy with `poetry init` and to allow us to specify additional information like readme, documentation link, repository link, etc.

Still a WIP, needs to run some more tests.

From Tiff:

If we do this, can we also add the semver stuff as well? Step 12 of the quick start guide:

```
[tool.semantic_release]
version_variable = "{{cookiecutter.project_slug}}/__init__.py:__version__"
version_source = "commit"
upload_to_pypi = "false"
patch_without_tag = "true"
```