### PR TITLE
✨ NEW: more robust treatment of package __version__ 

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__init__.py
@@ -1,1 +1,5 @@
-__version__ = "{{ cookiecutter.version }}"
+# importlib is included in the standard library for Python >= 3.8
+# here __version__ is obtained from installed version of package
+from importlib.metadata import version
+
+__version__ = version(__name__)

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -1,2 +1,1 @@
-from {{ cookiecutter.project_slug }} import __version__
 from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}


### PR DESCRIPTION
This PR removes manual definition of `__version__` from `__init__.py` and instead, uses `importlib.metadata.version()` to extract the version from the installed package. This means that when releasing new versions of the package, we only need to use `poetry version` to bump the version in `pyproject.toml` which is now the one and only true source of the pacakge's version.

I've also removed version testing in the test file, because that also required manually changing every new version. Advanced users can test version-related issues with their own custom functions.

Leaving open for now as I test things out on an example project...

Closes: #32 